### PR TITLE
feat(grpcdevtools): Preserve the original exception

### DIFF
--- a/src/PatrickJahr.Blazor.GrpcWeb.DevTools/GrpcMessageInterceptor.cs
+++ b/src/PatrickJahr.Blazor.GrpcWeb.DevTools/GrpcMessageInterceptor.cs
@@ -46,29 +46,15 @@ public partial class GrpcMessageInterceptor : Interceptor
 
     private async Task<Metadata> HandleServerStreamRequest<TRequest>(Task<Metadata> metaData, TRequest request, string method)
     {
-        try
-        {
-            var result = await metaData;
-            await _jsRuntime.HandleGrpcServerStreamRequest(method, request);
-            return result;
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException("Custom error", ex);
-        }
+        var result = await metaData;
+        await _jsRuntime.HandleGrpcServerStreamRequest(method, request);
+        return result;
     }
 
     private async Task<TResponse> HandleUnaryCall<TResponse, TRequest>(string method, TRequest request, Task<TResponse> inner)
     {
-        try
-        {
-            var result = await inner;
-            await _jsRuntime.HandleGrpcRequest(method, request, result);
-            return result;
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException("Custom error", ex);
-        }
+        var result = await inner;
+        await _jsRuntime.HandleGrpcRequest(method, request, result);
+        return result;
     }
 }


### PR DESCRIPTION
Its quite painful to have gRPC exceptions wrapped on the client with 'Custom error' as the message.
Given we're adding nothing else beyond that, I think it would be far more advantageous to preserve the original gRPC exception for logging/handling.

Consumers can then decide how they want to handle it.

Feel free to decline this PR or request any changes :)

If you're happy, would you release the new nuget version also? 